### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24.4.1-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Activate the pnpm version pinned by package.json's "packageManager" field so
+# installs are deterministic and work without a network prompt.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@10.14.0 --activate
+
+USER node

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,14 @@
+{
+  "name": "cloudflare-workers-hono",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "user": "node",
+  "install": "pnpm install --frozen-lockfile",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "pnpm dev"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent development environment for this Cloudflare Workers + Hono + TypeScript project. Because a committed `.cursor/environment.json` is the highest-precedence environment source, no competing dashboard configuration is created.

- `.cursor/Dockerfile` — base image `node:24.4.1-bookworm-slim` (matches the pinned `engines.node` and the CI Node version), with `git`/`curl`/`ca-certificates` installed and `pnpm@10.14.0` activated via corepack (matches `engines.pnpm` / `packageManager`).
- `.cursor/environment.json` — `install: pnpm install --frozen-lockfile` and a `dev` terminal running `pnpm dev` (wrangler dev server).

## Why a custom Dockerfile

The repo pins Node `24.4.1` in `engines` and CI, while the default Cloud Agent image ships Node 22. Pinning Node 24.4.1 removes the `Unsupported engine` warning pnpm prints on every invocation under Node 22, and matches CI exactly.

## Validation

Built the committed Dockerfile with a rootless container runtime and ran the project inside the resulting image:

| Check | Result |
| --- | --- |
| Image build from `.cursor/Dockerfile` | Succeeds |
| `node -v` in image | `v24.4.1` |
| `whoami` / `id` in image | `node` (uid/gid 1000) |
| `pnpm -v` / `git` / `curl` in image | `10.14.0` / present / present |
| `pnpm install --frozen-lockfile` in image | Succeeds, no engine warning |
| Install idempotence | Second run reports up to date, no lockfile changes |
| `pnpm test` (Vitest) in image | 1 file / 3 tests passed |
| `pnpm check` (Prettier) on the pinned toolchain | Passes |
| `pnpm dev` (wrangler) core action | Server ready; task create→list flow works (`POST /api/task/add` then `GET /api/task` returns the created task) |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46f554d3-7ee4-4719-b137-59904d8db2fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46f554d3-7ee4-4719-b137-59904d8db2fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

