### PR TITLE
Add HTTP QUERY method API (RFC 10008)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,14 +25,40 @@ describe('Hono App', () => {
     expect(data.requestId).toMatch(uuidPattern)
   })
 
+  describe('Sample QUERY API', () => {
+    it('QUERY /api/sample/search - リクエストボディでアイテムを検索できること', async () => {
+      const res = await app.request('/api/sample/search', {
+        method: 'QUERY',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: 'fruit' }),
+      })
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.results).toHaveLength(2)
+      expect(
+        data.results.every(
+          (item: { category: string }) => item.category === 'fruit',
+        ),
+      ).toBe(true)
+    })
+
+    it('QUERY /api/sample/search - Content-Typeが無い場合は415エラーになること', async () => {
+      const res = await app.request('/api/sample/search', {
+        method: 'QUERY',
+        body: JSON.stringify({ name: 'apple' }),
+      })
+      expect(res.status).toBe(415)
+    })
+  })
+
   describe('Global Error Handler', () => {
     it('予期せぬエラーが発生した場合、500エラーとなり機密情報が漏洩しないこと', async () => {
       const { Hono } = await import('hono')
       const { globalErrorHandler } = await import('../src/index')
       const testApp = new Hono()
-      
+
       testApp.onError(globalErrorHandler)
-      
+
       testApp.get('/force-error', () => {
         throw new Error('This is a highly secret database error')
       })
@@ -41,7 +67,7 @@ describe('Hono App', () => {
       console.error = () => {}
 
       const res = await testApp.request('/force-error')
-      
+
       console.error = originalConsoleError
 
       expect(res.status).toBe(500)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,32 +25,6 @@ describe('Hono App', () => {
     expect(data.requestId).toMatch(uuidPattern)
   })
 
-  describe('Sample QUERY API', () => {
-    it('QUERY /api/sample/search - リクエストボディでアイテムを検索できること', async () => {
-      const res = await app.request('/api/sample/search', {
-        method: 'QUERY',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ category: 'fruit' }),
-      })
-      expect(res.status).toBe(200)
-      const data = await res.json()
-      expect(data.results).toHaveLength(2)
-      expect(
-        data.results.every(
-          (item: { category: string }) => item.category === 'fruit',
-        ),
-      ).toBe(true)
-    })
-
-    it('QUERY /api/sample/search - Content-Typeが無い場合は415エラーになること', async () => {
-      const res = await app.request('/api/sample/search', {
-        method: 'QUERY',
-        body: JSON.stringify({ name: 'apple' }),
-      })
-      expect(res.status).toBe(415)
-    })
-  })
-
   describe('Global Error Handler', () => {
     it('予期せぬエラーが発生した場合、500エラーとなり機密情報が漏洩しないこと', async () => {
       const { Hono } = await import('hono')

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ app.use(
       'X-Custom-Header',
       'Upgrade-Insecure-Requests',
     ],
-    allowMethods: ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'DELETE'],
+    allowMethods: ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'DELETE', 'QUERY'],
     exposeHeaders: ['X-Custom-Header', 'Content-Disposition'],
     maxAge: 600,
     credentials: true,
@@ -57,7 +57,12 @@ export const globalErrorHandler: ErrorHandler = (err, c) => {
   }
 
   if (err instanceof HTTPException) {
-    console.error(`[HTTPException] ${err.status}:`, err.message, '\n', err.stack)
+    console.error(
+      `[HTTPException] ${err.status}:`,
+      err.message,
+      '\n',
+      err.stack,
+    )
     return err.getResponse()
   }
 

--- a/src/sample/index.ts
+++ b/src/sample/index.ts
@@ -36,6 +36,41 @@ sample.get('/query', (c) => {
   })
 })
 
+const sampleItems = [
+  { id: 1, name: 'apple', category: 'fruit' },
+  { id: 2, name: 'banana', category: 'fruit' },
+  { id: 3, name: 'carrot', category: 'vegetable' },
+  { id: 4, name: 'broccoli', category: 'vegetable' },
+]
+
+sample.query('/search', async (c) => {
+  const contentType = c.req.header('Content-Type')
+  if (!contentType?.startsWith('application/json')) {
+    throw new HTTPException(415, {
+      message: 'Content-Type must be application/json',
+    })
+  }
+
+  let body: { name?: string; category?: string } = {}
+  try {
+    body = await c.req.json()
+  } catch {
+    throw new HTTPException(400, { message: 'Invalid JSON body' })
+  }
+
+  let results = sampleItems
+  if (body.name !== undefined) {
+    const name = body.name.toLowerCase()
+    results = results.filter((item) => item.name.includes(name))
+  }
+  if (body.category !== undefined) {
+    const category = body.category.toLowerCase()
+    results = results.filter((item) => item.category === category)
+  }
+
+  return c.json({ query: body, results })
+})
+
 sample.get('/header', (c) => {
   const userAgent = c.req.header('User-Agent')
   const host = c.req.header('Host')

--- a/src/sample/index.ts
+++ b/src/sample/index.ts
@@ -36,41 +36,6 @@ sample.get('/query', (c) => {
   })
 })
 
-const sampleItems = [
-  { id: 1, name: 'apple', category: 'fruit' },
-  { id: 2, name: 'banana', category: 'fruit' },
-  { id: 3, name: 'carrot', category: 'vegetable' },
-  { id: 4, name: 'broccoli', category: 'vegetable' },
-]
-
-sample.query('/search', async (c) => {
-  const contentType = c.req.header('Content-Type')
-  if (!contentType?.startsWith('application/json')) {
-    throw new HTTPException(415, {
-      message: 'Content-Type must be application/json',
-    })
-  }
-
-  let body: { name?: string; category?: string } = {}
-  try {
-    body = await c.req.json()
-  } catch {
-    throw new HTTPException(400, { message: 'Invalid JSON body' })
-  }
-
-  let results = sampleItems
-  if (body.name !== undefined) {
-    const name = body.name.toLowerCase()
-    results = results.filter((item) => item.name.includes(name))
-  }
-  if (body.category !== undefined) {
-    const category = body.category.toLowerCase()
-    results = results.filter((item) => item.category === category)
-  }
-
-  return c.json({ query: body, results })
-})
-
 sample.get('/header', (c) => {
   const userAgent = c.req.header('User-Agent')
   const host = c.req.header('Host')

--- a/src/task/index.test.ts
+++ b/src/task/index.test.ts
@@ -52,7 +52,7 @@ describe('Task API', () => {
 
     // Act: 取得
     const res = await app.request(`/api/task/${targetId}`)
-    
+
     // Assert
     expect(res.status).toBe(200)
     const data = await res.json()
@@ -83,7 +83,7 @@ describe('Task API', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ completed: true, title: 'Updated Task' }),
     })
-    
+
     // Assert
     expect(res.status).toBe(200)
     const data = await res.json()
@@ -116,7 +116,7 @@ describe('Task API', () => {
     const res = await app.request(`/api/task/${targetId}`, {
       method: 'DELETE',
     })
-    
+
     // Assert
     expect(res.status).toBe(200)
     const data = await res.json()
@@ -134,5 +134,45 @@ describe('Task API', () => {
     expect(res.status).toBe(404)
     const data = await res.json()
     expect(data.error).toBe('Task not found')
+  })
+
+  it('QUERY /api/task/search - リクエストボディでタスクを検索できること', async () => {
+    const res = await app.request('/api/task/search', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ completed: false }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.tasks).toBeInstanceOf(Array)
+    expect(data.tasks.every((t: { completed: boolean }) => !t.completed)).toBe(
+      true,
+    )
+  })
+
+  it('QUERY /api/task/search - titleで部分一致検索できること', async () => {
+    const res = await app.request('/api/task/search', {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'sample' }),
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.tasks.length).toBeGreaterThan(0)
+    expect(
+      data.tasks.every((t: { title: string }) =>
+        t.title.toLowerCase().includes('sample'),
+      ),
+    ).toBe(true)
+  })
+
+  it('QUERY /api/task/search - Content-Typeが無い場合は415エラーになること', async () => {
+    const res = await app.request('/api/task/search', {
+      method: 'QUERY',
+      body: JSON.stringify({ completed: true }),
+    })
+    expect(res.status).toBe(415)
+    const data = await res.json()
+    expect(data.error).toBe('Content-Type must be application/json')
   })
 })

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -23,6 +23,40 @@ export const resetTasks = () => {
 // Initial seed
 resetTasks()
 
+// QUERY /search - Search tasks with a request body (RFC 10008)
+task.query('/search', async (c) => {
+  const contentType = c.req.header('Content-Type')
+  if (!contentType?.startsWith('application/json')) {
+    throw new ApiError(
+      415,
+      'Content-Type must be application/json',
+      'QUERY /search rejected due to missing or unsupported Content-Type',
+    )
+  }
+
+  let body: { title?: string; completed?: boolean } = {}
+  try {
+    body = await c.req.json()
+  } catch {
+    throw new ApiError(
+      400,
+      'Invalid JSON body',
+      'QUERY /search failed to parse request body',
+    )
+  }
+
+  let tasks = Array.from(taskMap.values())
+  if (body.title !== undefined) {
+    const title = body.title.toLowerCase()
+    tasks = tasks.filter((t) => t.title.toLowerCase().includes(title))
+  }
+  if (body.completed !== undefined) {
+    tasks = tasks.filter((t) => t.completed === body.completed)
+  }
+
+  return c.json({ tasks })
+})
+
 // GET / - Read all tasks
 task.get('/', (c) => {
   const tasks = Array.from(taskMap.values())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

2026年6月に標準化された [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html) の HTTP **QUERY** メソッドを、**Task API にのみ** 追加します。QUERY は GET と同様に **safe（安全）** かつ **idempotent（冪等）** ですが、リクエストボディを持てるため、複雑な読み取り専用クエリを `POST /search` の代わりに送れるようになります。

本プロジェクトは Hono 4.13.0 を使用しており、`app.query()` によるルーティングをサポートしています。

## 変更内容

- **`QUERY /api/task/search`** — JSON ボディの `title`（部分一致）/ `completed` でタスクを検索
- **CORS** — `allowMethods` に `QUERY` を追加（ブラウザからのクロスオリジンリクエストの preflight 対応）
- **テスト** — 検索成功時と `Content-Type` 未指定時の 415 エラーをカバー

## RFC 10008 への準拠

- エンドポイントは `Content-Type: application/json` を必須とし、未指定・非対応の場合は 415 を返す
- QUERY ハンドラは読み取り専用（状態変更なし）

## 使用例

```bash
curl -X QUERY http://localhost:8787/api/task/search \
  -H "Content-Type: application/json" \
  -d '{"completed": false}'
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7a4ff71-94d8-4ab7-9c1b-fa3a7b52c1e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7a4ff71-94d8-4ab7-9c1b-fa3a7b52c1e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

